### PR TITLE
baseline: add rootfs_overlay with dmesg.sh

### DIFF
--- a/configs/frags/baseline.config
+++ b/configs/frags/baseline.config
@@ -1,3 +1,4 @@
 BR2_PACKAGE_BOOTRR=y
 BR2_PACKAGE_UTIL_LINUX_DMESG=y
 BR2_PACKAGE_BUSYBOX_CONFIG_FRAGMENT_FILES="package/busybox/busybox-no-dmesg.config"
+BR2_ROOTFS_OVERLAY="kernelci/baseline/rootfs_overlay/"

--- a/kernelci/baseline/rootfs_overlay/opt/kernelci/dmesg.sh
+++ b/kernelci/baseline/rootfs_overlay/opt/kernelci/dmesg.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -e
+
+if [ "$KERNELCI_LAVA" = "y" ]; then
+    alias test-result='lava-test-case'
+else
+    alias test-result='echo'
+fi
+
+for level in crit alert emerg; do
+    dmesg --level=$level --notime -x -k > dmesg.$level
+    test -s dmesg.$level && res=fail || res=pass
+    count=$(cat dmesg.$level | wc -l)
+    cat dmesg.$level
+    test-result \
+        $level \
+        --result $res \
+        --measurement $count \
+        --units lines
+done
+
+exit 0


### PR DESCRIPTION
Add rootfs_overlay directory structure with dmesg.sh and enable it in
baseline.config.  This is to have the dmesg.sh script directly in the
baseline ramdisk and be able to call it directly in KernelCI jobs.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>