### PR TITLE
T20979 baseline: also include base overlay

### DIFF
--- a/configs/frags/baseline.config
+++ b/configs/frags/baseline.config
@@ -1,4 +1,4 @@
 BR2_PACKAGE_BOOTRR=y
 BR2_PACKAGE_UTIL_LINUX_DMESG=y
 BR2_PACKAGE_BUSYBOX_CONFIG_FRAGMENT_FILES="package/busybox/busybox-no-dmesg.config"
-BR2_ROOTFS_OVERLAY="kernelci/baseline/rootfs_overlay/"
+BR2_ROOTFS_OVERLAY="overlay kernelci/baseline/rootfs_overlay/"


### PR DESCRIPTION
The baseline config adds a new rootfs overlay, but it should also
include the base overlay.  Fix this by having the path for both
overlays in the baseline fragment.

Fixes: 24600c76ce51 ("baseline: add rootfs_overlay with dmesg.sh")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>