### PR TITLE
kernelci need UDEV for LAVA test disk

### DIFF
--- a/configs/frags/base.config
+++ b/configs/frags/base.config
@@ -41,3 +41,7 @@ BR2_ENABLE_LOCALE_WHITELIST="C en_US"
 
 # fs utils
 BR2_PACKAGE_E2FSPROGS=y
+
+# udev needed for generating /dev/disk/by-uuid
+BR2_TOOLCHAIN_BUILDROOT_WCHAR=y
+BR2_PACKAGE_EUDEV=y


### PR DESCRIPTION
LAVA mount test disk via /dev/disk/by-uuid/$UUID.
Thoses links are created by UDEV.
Nearly all BR arches have UDEV by default, but mips dont and so test disk
are not mounted when doing qemu+mips.

Signed-off-by: Corentin Labbe <clabbe@baylibre.com>