### PR TITLE
Copy buildroot config with other artifacts

### DIFF
--- a/configs/frags/build
+++ b/configs/frags/build
@@ -41,3 +41,5 @@ if [ $? = 0 ]; then
     tar -C output/host -Jcf output/images/host.tar.xz .
     (cd output/images; md5sum host.tar.xz > host.tar.xz.md5)
 fi
+
+cp .config output/images/config


### PR DESCRIPTION
For debugging, it is helpfull to have final config along with rootfs.
So after build let's copy buildroot config.