### PR TITLE
baseline: add tpm2-tools bootrr dependency

### DIFF
--- a/configs/frags/baseline.config
+++ b/configs/frags/baseline.config
@@ -1,4 +1,5 @@
 BR2_PACKAGE_BOOTRR=y
+BR2_PACKAGE_TPM2_TOOLS=y
 BR2_PACKAGE_UTIL_LINUX_DMESG=y
 BR2_PACKAGE_BUSYBOX_CONFIG_FRAGMENT_FILES="package/busybox/busybox-no-dmesg.config"
 BR2_ROOTFS_OVERLAY="overlay kernelci/baseline/rootfs_overlay/"

--- a/package/bootrr/Config.in
+++ b/package/bootrr/Config.in
@@ -1,4 +1,5 @@
 config BR2_PACKAGE_BOOTRR
 	bool "bootrr"
+	depends on BR2_PACKAGE_TPM2_TOOLS
 	help
 	  The bootrr test scripts.


### PR DESCRIPTION
Starting with PR #12, bootrr will depend on tpm2-tools to
run some TPM chip sanity checks on boot, so we need to
make this dependency explicit and for safety also enable
it directly in the baseline config fragment.

[1] https://github.com/kernelci/bootrr/pull/12

Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>