### PR TITLE
overlay: align dmesg.sh script with Debian-based rootfs

### DIFF
--- a/kernelci/baseline/rootfs_overlay/opt/kernelci/dmesg.sh
+++ b/kernelci/baseline/rootfs_overlay/opt/kernelci/dmesg.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+ret=0
+
 if [ "$KERNELCI_LAVA" = "y" ]; then
     alias test-result='lava-test-case'
 else
@@ -10,7 +12,17 @@ fi
 
 for level in crit alert emerg; do
     dmesg --level=$level --notime -x -k > dmesg.$level
-    test -s dmesg.$level && res=fail || res=pass
+    if grep -q "No irq handler for vector" dmesg.$level; then
+        echo "Ignoring:"
+        grep "No irq handler for vector" dmesg.$level
+        sed '/No irq handler for vector/d' dmesg.$level > dmesg.$level
+    fi
+    if [ -s "dmesg.$level" ]; then
+        res=fail
+        ret=1
+    else
+        res=pass
+    fi
     count=$(cat dmesg.$level | wc -l)
     cat dmesg.$level
     test-result \
@@ -20,4 +32,4 @@ for level in crit alert emerg; do
         --units lines
 done
 
-exit 0
+exit $ret


### PR DESCRIPTION
Script "dmesg.sh" available in the baseline rootfs became outdated compared to Debian-based rootfs images. This patch updates it to include changes introduced in that script:

- a4e885cc673cfbef52f3e664d498af8d53b5abc0
- 3e6da7b68fced89c6612c3e2c58a21f2a1cbfb91
    
(from https://github.com/kernelci/kernelci-core repository)