### PR TITLE
configs/frags/base: drop legacy configuration

### DIFF
--- a/configs/frags/base.config
+++ b/configs/frags/base.config
@@ -31,10 +31,6 @@ BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_EUDEV=y
 # misc. tools
 BR2_PACKAGE_PCIUTILS=y
 
-# ensure older kernel support (v3.2 is oldest as of 2016.05)
-# NOTE: arm64 only exists as of v3.10
-BR2_KERNEL_HEADERS_4_4=y
-
 # purge locales to reduce rootfs size
 BR2_ENABLE_LOCALE_PURGE=y
 BR2_ENABLE_LOCALE_WHITELIST="C en_US"


### PR DESCRIPTION
Kernel 4.4 is no longer supported in Buildroot. Attempts at building images with old config failed with a following message:

"You have legacy configuration in your .config! Please check your configuration."